### PR TITLE
Use play-iteratees for 2.11 and update to current release. move

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -5,7 +5,7 @@ object ApplicationBuild extends Build {
   override lazy val settings = super.settings ++
     Seq(
       name := "sentinel",
-      version := "0.7.5",
+      version := "0.7.5.1",
       organization := "nl.gideondk",
       scalaVersion := "2.11.1",
       parallelExecution in Test := false,
@@ -22,12 +22,12 @@ object ApplicationBuild extends Build {
     )
 
   val appDependencies = Seq(
-    "org.scalatest" %% "scalatest" % "2.1.4" % "test",
+    "org.scalatest" %% "scalatest" % "2.2.0" % "test",
 
-    "com.typesafe.play" % "play-iteratees_2.10" % "2.3.0",
+    "com.typesafe.play" %% "play-iteratees" % "2.3.1",
 
     "com.typesafe.akka" %% "akka-actor" % "2.3.4",
-    "com.typesafe.akka" %% "akka-testkit" % "2.3.4"
+    "com.typesafe.akka" %% "akka-testkit" % "2.3.4" % "test"
   )
 
   lazy val root = Project(id = "sentinel",


### PR DESCRIPTION
I ran into a few problems using the current head due to inclusion of the 2.10 runtime included via play-iteratees with also gets upgraded to current. this fixes that and also moves akka-testkit to the test scope and updates scalatest to current.
