### PR TITLE
Don't force materializer to be an ActorMaterializer

### DIFF
--- a/src/main/scala/nl/gideondk/sentinel/client/Client.scala
+++ b/src/main/scala/nl/gideondk/sentinel/client/Client.scala
@@ -55,20 +55,20 @@ object Client {
 
   def apply[Cmd, Evt](hosts: Source[HostEvent, NotUsed], resolver: Resolver[Evt],
                       shouldReact: Boolean, inputOverflowStrategy: OverflowStrategy,
-                      protocol: BidiFlow[Cmd, ByteString, ByteString, Evt, Any])(implicit system: ActorSystem, mat: ActorMaterializer, ec: ExecutionContext): Client[Cmd, Evt] = {
+                      protocol: BidiFlow[Cmd, ByteString, ByteString, Evt, Any])(implicit system: ActorSystem, mat: Materializer, ec: ExecutionContext): Client[Cmd, Evt] = {
     val processor = Processor[Cmd, Evt](resolver, Config.producerParallelism)
     new Client(hosts, ClientConfig.connectionsPerHost, ClientConfig.maxFailuresPerHost, ClientConfig.failureRecoveryPeriod, ClientConfig.inputBufferSize, inputOverflowStrategy, processor, protocol.reversed)
   }
 
   def apply[Cmd, Evt](hosts: List[Host], resolver: Resolver[Evt],
                       shouldReact: Boolean, inputOverflowStrategy: OverflowStrategy,
-                      protocol: BidiFlow[Cmd, ByteString, ByteString, Evt, Any])(implicit system: ActorSystem, mat: ActorMaterializer, ec: ExecutionContext): Client[Cmd, Evt] = {
+                      protocol: BidiFlow[Cmd, ByteString, ByteString, Evt, Any])(implicit system: ActorSystem, mat: Materializer, ec: ExecutionContext): Client[Cmd, Evt] = {
     val processor = Processor[Cmd, Evt](resolver, Config.producerParallelism)
     new Client(Source(hosts.map(HostUp)), ClientConfig.connectionsPerHost, ClientConfig.maxFailuresPerHost, ClientConfig.failureRecoveryPeriod, ClientConfig.inputBufferSize, inputOverflowStrategy, processor, protocol.reversed)
   }
 
   def flow[Cmd, Evt](hosts: Source[HostEvent, NotUsed], resolver: Resolver[Evt],
-                     shouldReact: Boolean = false, protocol: BidiFlow[Cmd, ByteString, ByteString, Evt, Any])(implicit system: ActorSystem, mat: ActorMaterializer, ec: ExecutionContext) = {
+                     shouldReact: Boolean = false, protocol: BidiFlow[Cmd, ByteString, ByteString, Evt, Any])(implicit system: ActorSystem, mat: Materializer, ec: ExecutionContext) = {
     val processor = Processor[Cmd, Evt](resolver, Config.producerParallelism)
     type Context = Promise[Event[Evt]]
 
@@ -100,7 +100,7 @@ object Client {
 
   def rawFlow[Context, Cmd, Evt](hosts: Source[HostEvent, NotUsed], resolver: Resolver[Evt],
                                  shouldReact: Boolean = false,
-                                 protocol: BidiFlow[Cmd, ByteString, ByteString, Evt, Any])(implicit system: ActorSystem, mat: ActorMaterializer, ec: ExecutionContext) = {
+                                 protocol: BidiFlow[Cmd, ByteString, ByteString, Evt, Any])(implicit system: ActorSystem, mat: Materializer, ec: ExecutionContext) = {
     val processor = Processor[Cmd, Evt](resolver, Config.producerParallelism)
 
     Flow.fromGraph(GraphDSL.create(hosts) { implicit b ⇒
@@ -129,7 +129,7 @@ object Client {
 class Client[Cmd, Evt](hosts: Source[HostEvent, NotUsed],
                        connectionsPerHost: Int, maximumFailuresPerHost: Int, recoveryPeriod: FiniteDuration,
                        inputBufferSize: Int, inputOverflowStrategy: OverflowStrategy,
-                       processor: Processor[Cmd, Evt], protocol: BidiFlow[ByteString, Evt, Cmd, ByteString, Any])(implicit system: ActorSystem, mat: ActorMaterializer) {
+                       processor: Processor[Cmd, Evt], protocol: BidiFlow[ByteString, Evt, Cmd, ByteString, Any])(implicit system: ActorSystem, mat: Materializer) {
 
   type Context = Promise[Event[Evt]]
 

--- a/src/main/scala/nl/gideondk/sentinel/client/ClientStage.scala
+++ b/src/main/scala/nl/gideondk/sentinel/client/ClientStage.scala
@@ -41,7 +41,7 @@ import nl.gideondk.sentinel.client.ClientStage._
 
 class ClientStage[Context, Cmd, Evt](connectionsPerHost: Int, maximumFailuresPerHost: Int,
                                      recoveryPeriod: FiniteDuration, finishGracefully: Boolean, processor: Processor[Cmd, Evt],
-                                     protocol: BidiFlow[ByteString, Evt, Cmd, ByteString, Any])(implicit system: ActorSystem, mat: ActorMaterializer)
+                                     protocol: BidiFlow[ByteString, Evt, Cmd, ByteString, Any])(implicit system: ActorSystem, mat: Materializer)
 
     extends GraphStage[BidiShape[(Command[Cmd], Context), (Try[Event[Evt]], Context), HostEvent, HostEvent]] {
 

--- a/src/main/scala/nl/gideondk/sentinel/server/Server.scala
+++ b/src/main/scala/nl/gideondk/sentinel/server/Server.scala
@@ -2,7 +2,7 @@ package nl.gideondk.sentinel.server
 
 import akka.actor.ActorSystem
 import akka.stream.scaladsl.{ BidiFlow, Flow, GraphDSL, Sink, Source, Tcp }
-import akka.stream.{ ActorMaterializer, FlowShape }
+import akka.stream.{ Materializer, FlowShape }
 import akka.util.ByteString
 import nl.gideondk.sentinel.pipeline.{ Processor, Resolver }
 
@@ -10,7 +10,7 @@ import scala.concurrent.ExecutionContext
 import scala.util.{ Failure, Success }
 
 object Server {
-  def apply[Cmd, Evt](interface: String, port: Int, resolver: Resolver[Evt], protocol: BidiFlow[ByteString, Evt, Cmd, ByteString, Any])(implicit system: ActorSystem, mat: ActorMaterializer, ec: ExecutionContext): Unit = {
+  def apply[Cmd, Evt](interface: String, port: Int, resolver: Resolver[Evt], protocol: BidiFlow[ByteString, Evt, Cmd, ByteString, Any])(implicit system: ActorSystem, mat: Materializer, ec: ExecutionContext): Unit = {
 
     val handler = Sink.foreach[Tcp.IncomingConnection] { conn ⇒
       val processor = Processor[Cmd, Evt](resolver, 1, true)

--- a/src/test/scala/nl/gideondk/sentinel/protocol/SimpleMessage.scala
+++ b/src/test/scala/nl/gideondk/sentinel/protocol/SimpleMessage.scala
@@ -1,6 +1,6 @@
 package nl.gideondk.sentinel.protocol
 
-import akka.stream.{ ActorMaterializer, Materializer }
+import akka.stream.Materializer
 import akka.stream.scaladsl.{ BidiFlow, Framing, Sink, Source }
 import akka.util.{ ByteString, ByteStringBuilder }
 import nl.gideondk.sentinel.pipeline.Resolver


### PR DESCRIPTION
There are other materializer implementations that should also work here, and frameworks like Play and Lagom by default only make a Materializer available for general use.