### PR TITLE
Don't load Typesafe config yourself

### DIFF
--- a/src/main/scala/nl/gideondk/sentinel/Config.scala
+++ b/src/main/scala/nl/gideondk/sentinel/Config.scala
@@ -1,9 +1,20 @@
 package nl.gideondk.sentinel
 
-import com.typesafe.config.ConfigFactory
+import akka.actor.{ ActorSystem, ExtendedActorSystem, Extension, ExtensionId, ExtensionIdProvider }
+import com.typesafe.config.{ Config ⇒ TypesafeConfig }
 
-object Config {
-  private lazy val config = ConfigFactory.load().getConfig("nl.gideondk.sentinel")
-
+class Config(config: TypesafeConfig) extends Extension {
   val producerParallelism = config.getInt("pipeline.parallelism")
 }
+
+object Config extends ExtensionId[Config] with ExtensionIdProvider {
+  override def lookup = Config
+  override def createExtension(system: ExtendedActorSystem) =
+    new Config(system.settings.config.getConfig("nl.gideondk.sentinel"))
+  override def get(system: ActorSystem): Config = super.get(system)
+
+  private def config(implicit system: ActorSystem) = apply(system)
+
+  def producerParallelism(implicit system: ActorSystem) = config.producerParallelism
+}
+


### PR DESCRIPTION
Sentinal shouldn't load Typesafe config itself, since this undermines the ability to configure it per test, or to use a custom load mechanism for Typesafe config. It also shouldn't store the config statically.

This converts the config to an Akka extension, and uses the config loaded by Akka, which gives end users the flexbility to configure it however they want, including programatically. By making it an Akka extension, it means the configuration values are only read from the configuration once per actor system (they are effectively cached for each use).