### PR TITLE
Tell travis to use JDK8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: scala
 scala:
   - 2.11.8
+jdk:
+  - oraclejdk8
 script: "sbt ++$TRAVIS_SCALA_VERSION test"


### PR DESCRIPTION
Akka 2.4 dropped support for JDK7, so Travis must use JDK8.